### PR TITLE
Cw add support for payment intents and payment methods

### DIFF
--- a/lib/fake_stripe.rb
+++ b/lib/fake_stripe.rb
@@ -8,7 +8,7 @@ module FakeStripe
 
   VALID_CARD_NUMBER = '4242424242424242'
   STRIPE_OBJECTS = %w{card charge coupon customer invoice invoiceitem plan
-    recipient refund subscription token transfer payment_intent connection_token}.freeze
+    recipient refund subscription token transfer payment_intent payment_method connection_token}.freeze
   CARD_OBJECT_TYPE = "card"
   BANK_ACCOUNT_OBJECT_TYPE = "bank_account"
 

--- a/lib/fake_stripe/fixtures/attach_payment_method_to_customer.json
+++ b/lib/fake_stripe/fixtures/attach_payment_method_to_customer.json
@@ -1,0 +1,41 @@
+{
+  "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 8,
+    "exp_year": 2021,
+    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1578693892,
+  "customer": "cus_GWYi294gYXLNRR",
+  "livemode": false,
+  "metadata": {},
+  "type": "card"
+}

--- a/lib/fake_stripe/fixtures/create_payment_method.json
+++ b/lib/fake_stripe/fixtures/create_payment_method.json
@@ -1,0 +1,41 @@
+{
+  "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 8,
+    "exp_year": 2021,
+    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1578693892,
+  "customer": null,
+  "livemode": false,
+  "metadata": {},
+  "type": "card"
+}

--- a/lib/fake_stripe/fixtures/create_refund.json
+++ b/lib/fake_stripe/fixtures/create_refund.json
@@ -1,0 +1,16 @@
+{
+  "id": "re_1EYlNRL91mzKIzpGYUuIL6pe",
+  "object": "refund",
+  "amount": 2000,
+  "balance_transaction": null,
+  "charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
+  "created": 1557543357,
+  "currency": "usd",
+  "metadata": {},
+  "payment_intent": "pi_1EWE2PL91mzKIzpGIWTswBfS",
+  "reason": "expired_uncaptured_charge",
+  "receipt_number": null,
+  "source_transfer_reversal": null,
+  "status": "succeeded",
+  "transfer_reversal": null
+}

--- a/lib/fake_stripe/fixtures/detach_payment_method_from_customer.json
+++ b/lib/fake_stripe/fixtures/detach_payment_method_from_customer.json
@@ -1,0 +1,41 @@
+{
+  "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 8,
+    "exp_year": 2021,
+    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1578693892,
+  "customer": null,
+  "livemode": false,
+  "metadata": {},
+  "type": "card"
+}

--- a/lib/fake_stripe/fixtures/list_payment_methods.json
+++ b/lib/fake_stripe/fixtures/list_payment_methods.json
@@ -1,0 +1,48 @@
+{
+  "object": "list",
+  "url": "/v1/payment_methods",
+  "has_more": false,
+  "data": [
+    {
+      "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": null,
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": null,
+        "phone": null
+      },
+      "card": {
+        "brand": "visa",
+        "checks": {
+          "address_line1_check": null,
+          "address_postal_code_check": null,
+          "cvc_check": null
+        },
+        "country": "US",
+        "exp_month": 8,
+        "exp_year": 2021,
+        "fingerprint": "Xt5EWLLDS7FJjR1c",
+        "funding": "credit",
+        "generated_from": null,
+        "last4": "4242",
+        "three_d_secure_usage": {
+          "supported": true
+        },
+        "wallet": null
+      },
+      "created": 1578693892,
+      "customer": null,
+      "livemode": false,
+      "metadata": {},
+      "type": "card"
+    }
+  ]
+}

--- a/lib/fake_stripe/fixtures/retreive_payment_method.json
+++ b/lib/fake_stripe/fixtures/retreive_payment_method.json
@@ -1,0 +1,41 @@
+{
+  "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 8,
+    "exp_year": 2021,
+    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1578693892,
+  "customer": "cus_GWYi294gYXLNRR",
+  "livemode": false,
+  "metadata": {},
+  "type": "card"
+}

--- a/lib/fake_stripe/fixtures/update_payment_method.json
+++ b/lib/fake_stripe/fixtures/update_payment_method.json
@@ -1,0 +1,43 @@
+{
+  "id": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": null,
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": null,
+    "phone": null
+  },
+  "card": {
+    "brand": "visa",
+    "checks": {
+      "address_line1_check": null,
+      "address_postal_code_check": null,
+      "cvc_check": null
+    },
+    "country": "US",
+    "exp_month": 8,
+    "exp_year": 2021,
+    "fingerprint": "Xt5EWLLDS7FJjR1c",
+    "funding": "credit",
+    "generated_from": null,
+    "last4": "4242",
+    "three_d_secure_usage": {
+      "supported": true
+    },
+    "wallet": null
+  },
+  "created": 1578693892,
+  "customer": "cus_GWYi294gYXLNRR",
+  "livemode": false,
+  "metadata": {
+    "order_id": "6735"
+  },
+  "type": "card"
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -57,6 +57,33 @@ module FakeStripe
       json_response 200, fixture('list_customers')
     end
 
+    # Pyment Methods
+    post '/v1/payment_methods' do
+      FakeStripe.card_count += 1
+      json_response 200, fixture('create_payment_method')
+    end
+
+    get '/v1/payment_methods/:payment_method_id' do
+      json_response 200, fixture('retrieve_payment_method')
+    end
+
+    post '/v1/payment_methods/:payment_method_id' do
+      json_response 200, fixture('update_payment_method')
+    end
+
+    get '/v1/payment_methods' do
+      json_response 200, fixture('list_payment_methods')
+    end
+
+    post '/v1/payment_methods/:payment_method_id/attach' do
+      json_response 200, fixture('attach_payment_method_to_customer')
+    end
+
+    post '/v1/payment_methods/:payment_method_id/detach' do
+      json_response 200, fixture('detach_payment_method_from_customer')
+    end
+
+
     # Cards
     post '/v1/customers/:customer_id/sources' do
       FakeStripe.card_count += 1
@@ -361,18 +388,19 @@ module FakeStripe
     end
 
     # Payment Intents
-    post '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K' do
+    post '/v1/payment_intents' do
+      json_response 200, fixture("create_payment_intent")
+    end
+
+    post '/v1/payment_intents/:payment_intent_id' do
       json_response 200, fixture("retrieve_payment_intent")
     end
 
-    get '/v1/payment_intents' do
-      json_response 200, fixture("create_payment_intent")
-    end
-    post '/v1/payment_intents/pi_1EXK12L91mzKIzpGuXKit4pE/confirm' do
+    post '/v1/payment_intents/:payment_intent_id/confirm' do
       json_response 200, fixture("confirm_payment_intent")
     end
 
-    post '/v1/payment_intents/pi_1EXK12L91mzKIzpGuXKit4pE/capture' do
+    post '/v1/payment_intents/:payment_intent_id/capture' do
       json_response 200, fixture("capture_payment_intent")
     end
 

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -9,8 +9,6 @@ describe 'Stub app' do
     'GET charges/:charge_id' => { route: '/v1/charges/1', method: :get },
     'POST charges/:charge_id' => { route: '/v1/charges/1', method: :post },
     'POST refunds' => { route: '/v1/refunds', method: :post },
-    'POST charges/:charge_id/refund' =>
-    { route: '/v1/charges/1/refund', method: :post },
     'POST charges/:charge_id/capture' =>
       { route: '/v1/charges/1/capture', method: :post },
     'GET charges' => { route: '/v1/charges', method: :get },
@@ -33,6 +31,19 @@ describe 'Stub app' do
        { route: '/v1/customers/1/sources/1', method: :delete },
     'GET customers/:customer_id/sources' =>
        { route: '/v1/customers/1/sources', method: :get },
+    # Payment Methods
+    'POST payment_methods' =>
+       { route: '/v1/payment_methods', method: :post },
+    'GET payment_methods/:payment_method_id' =>
+       { route: '/v1/payment_methods/:payment_method_id', method: :get },
+    'POST payment_methods/:payment_method_id' =>
+       { route: '/v1/payment_methods/:payment_method_id', method: :post },
+    'GET payment_methods' =>
+       { route: '/v1/payment_methods/:customer_id/:type', method: :get },
+    'POST payment_methods/attach' =>
+       { route: '/v1/payment_methods/attach', method: :post },
+    'POST payment_methods/dettach' =>
+       { route: '/v1/payment_methods/detach', method: :post },
     # Subscriptions
     'POST customers/:customer_id/subscriptions' =>
        { route: '/v1/customers/1/subscriptions', method: :post },
@@ -124,7 +135,10 @@ describe 'Stub app' do
     'GET balance/history' => { route: '/v1/balance/history', method: :get },
     # Payment Intents
     'POST payment_intents' => { route: '/v1/payment_intents', method: :post },
-    'POST payment_intents/:payment_intent_id' => { route: '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K', method: :get },
+    'GET payment_intents' => { route: '/v1/payment_intents', method: :get },
+    'GET payment_intents/:payment_intent_id' => { route: '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K', method: :get },
+    'POST payment_intents/:payment_intent_id' => { route: '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K', method: :post },
+    'POST payment_intents/:payment_intent_id/confirm' => { route: '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K/capture', method: :post },
     'POST payment_intents/:payment_intent_id/capture' => { route: '/v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K/capture', method: :post },
     # Events
     'GET events/:event_id' => { route: '/v1/events/1', method: :get },

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -1,6 +1,14 @@
 require 'spec_helper'
 
 describe FakeStripe::StubApp do
+  # Accounts
+  describe "POST /v1/accounts" do
+    it "returns an account response" do
+      result = Stripe::Account.create
+
+      expect(result.object).to eq("account")
+    end
+  end
   describe "GET /v1/accounts/:account_id" do
     it "returns an account response" do
       result = Stripe::Account.retrieve("stripe-account-id")
@@ -28,6 +36,7 @@ describe FakeStripe::StubApp do
     end
   end
 
+  # Terminal
   describe "POST v1/connection_tokens" do
     it "returns a connection token" do
       result = Stripe::Terminal::ConnectionToken.create
@@ -36,49 +45,60 @@ describe FakeStripe::StubApp do
     end
   end
 
-  # describe "POST v1/payment_intents" do
-  #   it "returns a payment intent" do
-  #     params = {
-  #       amount: 10000,
-  #       payment_method_types: ["card_present"],
-  #       capture_method: "manual",
-  #       on_behalf_of: Stripe::Account.create.id,
-  #       statement_descriptor: "Demo University",
-  #       metadata: {
-  #         category_id: 1,
-  #         contribution_id: 1,
-  #         project_id: 1,
-  #         payer_name: "Frank Sinatra",
-  #         payer_email: "frank@example.com"
-  #       },
-  #       transfer_data: {
-  #         destination: "acct_1A1xvnHNvvp0Twf9",
-  #         currency: "USD"
-  #       }
-  #     }
-  #     result = Stripe::PaymentIntent.create(params)
-  #
-  #     expect(result.object.object).to eq("payment_intent")
-  #   end
-  # end
-  #
-  # describe "POST v1/payment_intents/pi_1EXXWCL91mzKIzpGtqrOHA7K/capture" do
-  #   it "captures a payment intent" do
-  #     result = Stripe::PaymentIntent.create
-  #     result = result.capture
-  #
-  #     expect(result.object.object).to eq("payment_intent")
-  #   end
-  # end
+  # Payment Intents
+  describe "POST v1/payment_intents" do
+    it "returns a payment intent" do
+      params = {
+        amount: 10000,
+        payment_method_types: ["card_present"],
+        capture_method: "manual",
+        on_behalf_of: Stripe::Account.create.id,
+        statement_descriptor: "Demo University",
+        metadata: {
+          category_id: 1,
+          contribution_id: 1,
+          project_id: 1,
+          payer_name: "Frank Sinatra",
+          payer_email: "frank@example.com"
+        },
+        transfer_data: {
+          destination: "acct_1A1xvnHNvvp0Twf9",
+          currency: "USD"
+        }
+      }
+      result = Stripe::PaymentIntent.create(params)
 
-  describe "POST /v1/accounts" do
-    it "returns an account response" do
-      result = Stripe::Account.create
-
-      expect(result.object).to eq("account")
+      expect(result.object.object).to eq("payment_intent")
     end
   end
 
+  describe "GET v1/payment_intents/:payment_intent_id" do
+    it "returns a payment intent" do
+      result = Stripe::PaymentIntent.create
+
+      expect(result.object.object).to eq("payment_intent")
+    end
+  end
+
+  describe "POST v1/payment_intents/:payment_intent_id/confirm" do
+    it "confirms a payment intent" do
+      payment_intent = Stripe::PaymentIntent.create
+      result = Stripe::PaymentIntent.confirm(payment_intent.object.id)
+
+      expect(result.object).to eq("payment_intent")
+    end
+  end
+
+  describe "POST v1/payment_intents/:payment_intent_id/capture" do
+    it "captures a payment intent" do
+      payment_intent = Stripe::PaymentIntent.create
+      result = Stripe::PaymentIntent.capture(payment_intent.object.id)
+
+      expect(result.object.object).to eq("charge")
+    end
+  end
+
+  # Refunds
   describe 'POST /v1/charges' do
     it 'returns a fake charge response' do
       result = Stripe::Charge.create
@@ -93,6 +113,7 @@ describe FakeStripe::StubApp do
     end
   end
 
+  # Refunds
   describe 'POST /v1/refunds' do
     it 'returns a fake refund response' do
       result = Stripe::Refund.create(charge: 'ABC123')
@@ -107,20 +128,7 @@ describe FakeStripe::StubApp do
     end
   end
 
-  describe 'POST /v1/charges/:charge_id/refund' do
-    it 'returns a fake refund response' do
-      result = Stripe::Charge.retrieve('ABC123').refund
-
-      expect(result.refunded).to eq true
-    end
-
-    it 'increments the refund counter' do
-      expect do
-        Stripe::Charge.retrieve('ABC123').refund
-      end.to change(FakeStripe, :refund_count).by(1)
-    end
-  end
-
+  # Customers
   describe "POST /v1/customers" do
     it "increments the customer counter" do
       expect do
@@ -139,6 +147,7 @@ describe FakeStripe::StubApp do
     end
   end
 
+  # Subscriptions
   describe "POST /v1/customers/:customer_id/subscriptions" do
     it "increments the subscription counter" do
       customer = Stripe::Customer.retrieve("ABC123")
@@ -149,6 +158,82 @@ describe FakeStripe::StubApp do
     end
   end
 
+  # Payment Methods
+  describe "POST /v1/payment_methods" do
+    it "increments the card counter" do
+      expect do
+        payment_method = Stripe::PaymentMethod.create({
+          type: "card",
+          card: {
+            number: "4242424242424242",
+            exp_month: "1",
+            exp_year: "2028",
+            cvc: "321",
+          }
+        })
+      end.to change(FakeStripe, :card_count).by(1)
+    end
+  end
+
+  describe "GET /v1/payment_methods/:payment_method_id" do
+    it "returns a payment method" do
+      result = Stripe::PaymentMethod.create
+      expect(result.object).to eq("payment_method")
+    end
+  end
+
+  describe "POST /v1/payment_methods/:payment_method_id" do
+    it "updates a payment method" do
+      payment_method = Stripe::PaymentMethod.create
+      result = Stripe::PaymentMethod.update(
+        payment_method.id,
+        {exp_year: "2024"},
+      )
+
+      expect(result.object).to eq("payment_method")
+    end
+  end
+
+  describe "GET /v1/payment_methods" do
+    it "returns a list of a customers payment methods" do
+      result = Stripe::PaymentMethod.list({
+        customer: Stripe::Customer.create.id,
+        type: "card",
+      })
+
+      expect(result.count).to eq(1)
+      expect(result.first.object).to eq("payment_method")
+    end
+  end
+
+  describe "POST /v1/payment_methods/:payment_method_id/attach" do
+    it "attaches a payment method to a customer" do
+      customer = Stripe::Customer.create
+      payment_method = Stripe::PaymentMethod.create
+
+      result = Stripe::PaymentMethod.attach(
+        payment_method.id,
+        {customer: customer.id},
+      )
+
+      expect(result.object).to eq("payment_method")
+    end
+  end
+
+  describe "POST /v1/payment_methods/:payment_method_id/dettach" do
+    it "attaches a payment method to a customer" do
+      customer = Stripe::Customer.create
+      payment_method = Stripe::PaymentMethod.create
+
+      result = Stripe::PaymentMethod.detach(
+        payment_method.id,
+      )
+
+      expect(result.object).to eq("payment_method")
+    end
+  end
+
+  # Plans
   describe "POST /v1/plans" do
     it "increments the plan counter" do
       expect do


### PR DESCRIPTION
Adds support for Payment Methods to address the failing specs in PR https://github.com/givecampus/givecampus/pull/8573, which makes calls to `Stripe::PaymentMethod.list`, which is not supported by our current version of FakeStripe.

Also fixes the existing specs around Payment Intents