### PR TITLE
Add support for CountrySpec API

### DIFF
--- a/lib/fake_stripe/fixtures/list_country_specs.json
+++ b/lib/fake_stripe/fixtures/list_country_specs.json
@@ -1,0 +1,140 @@
+{
+  "object": "list",
+  "url": "/v1/country_specs",
+  "has_more": false,
+  "data": [
+    {
+      "id": "US",
+      "object": "country_spec",
+      "default_currency": "usd",
+      "supported_bank_account_currencies": {
+        "usd": [
+          "US"
+        ]
+      },
+      "supported_payment_currencies": [
+        "usd",
+        "aed",
+        "afn",
+        "..."
+      ],
+      "supported_payment_methods": [
+        "ach",
+        "card",
+        "stripe"
+      ],
+      "supported_transfer_countries": [
+        "US",
+        "AT",
+        "AU",
+        "BE",
+        "BG",
+        "CA",
+        "CH",
+        "CY",
+        "CZ",
+        "DE",
+        "DK",
+        "EE",
+        "ES",
+        "FI",
+        "FR",
+        "GB",
+        "GR",
+        "HK",
+        "IE",
+        "IT",
+        "LT",
+        "LU",
+        "LV",
+        "MT",
+        "NL",
+        "NO",
+        "NZ",
+        "PL",
+        "PT",
+        "RO",
+        "SE",
+        "SG",
+        "SI",
+        "SK"
+      ],
+      "verification_fields": {
+        "company": {
+          "additional": [
+            "representative.verification.document"
+          ],
+          "minimum": [
+            "business_profile.mcc",
+            "business_profile.url",
+            "business_type",
+            "company.address.city",
+            "company.address.line1",
+            "company.address.postal_code",
+            "company.address.state",
+            "company.name",
+            "company.owners_provided",
+            "company.phone",
+            "company.tax_id",
+            "external_account",
+            "owners.address.city",
+            "owners.address.line1",
+            "owners.address.postal_code",
+            "owners.address.state",
+            "owners.dob.day",
+            "owners.dob.month",
+            "owners.dob.year",
+            "owners.email",
+            "owners.first_name",
+            "owners.last_name",
+            "owners.phone",
+            "owners.ssn_last_4",
+            "owners.verification.document",
+            "representative.address.city",
+            "representative.address.line1",
+            "representative.address.postal_code",
+            "representative.address.state",
+            "representative.dob.day",
+            "representative.dob.month",
+            "representative.dob.year",
+            "representative.email",
+            "representative.first_name",
+            "representative.last_name",
+            "representative.phone",
+            "representative.relationship.executive",
+            "representative.relationship.title",
+            "representative.ssn_last_4",
+            "tos_acceptance.date",
+            "tos_acceptance.ip"
+          ]
+        },
+        "individual": {
+          "additional": [
+            "individual.id_number",
+            "individual.verification.document"
+          ],
+          "minimum": [
+            "business_profile.mcc",
+            "business_profile.url",
+            "business_type",
+            "external_account",
+            "individual.address.city",
+            "individual.address.line1",
+            "individual.address.postal_code",
+            "individual.address.state",
+            "individual.dob.day",
+            "individual.dob.month",
+            "individual.dob.year",
+            "individual.email",
+            "individual.first_name",
+            "individual.last_name",
+            "individual.phone",
+            "individual.ssn_last_4",
+            "tos_acceptance.date",
+            "tos_acceptance.ip"
+          ]
+        }
+      }
+    }
+  ]
+}

--- a/lib/fake_stripe/fixtures/retrieve_country_spec.json
+++ b/lib/fake_stripe/fixtures/retrieve_country_spec.json
@@ -1,0 +1,133 @@
+{
+  "id": "US",
+  "object": "country_spec",
+  "default_currency": "usd",
+  "supported_bank_account_currencies": {
+    "usd": [
+      "US"
+    ]
+  },
+  "supported_payment_currencies": [
+    "usd",
+    "aed",
+    "afn",
+    "..."
+  ],
+  "supported_payment_methods": [
+    "ach",
+    "card",
+    "stripe"
+  ],
+  "supported_transfer_countries": [
+    "US",
+    "AT",
+    "AU",
+    "BE",
+    "BG",
+    "CA",
+    "CH",
+    "CY",
+    "CZ",
+    "DE",
+    "DK",
+    "EE",
+    "ES",
+    "FI",
+    "FR",
+    "GB",
+    "GR",
+    "HK",
+    "IE",
+    "IT",
+    "LT",
+    "LU",
+    "LV",
+    "MT",
+    "NL",
+    "NO",
+    "NZ",
+    "PL",
+    "PT",
+    "RO",
+    "SE",
+    "SG",
+    "SI",
+    "SK"
+  ],
+  "verification_fields": {
+    "company": {
+      "additional": [
+        "representative.verification.document"
+      ],
+      "minimum": [
+        "business_profile.mcc",
+        "business_profile.url",
+        "business_type",
+        "company.address.city",
+        "company.address.line1",
+        "company.address.postal_code",
+        "company.address.state",
+        "company.name",
+        "company.owners_provided",
+        "company.phone",
+        "company.tax_id",
+        "external_account",
+        "owners.address.city",
+        "owners.address.line1",
+        "owners.address.postal_code",
+        "owners.address.state",
+        "owners.dob.day",
+        "owners.dob.month",
+        "owners.dob.year",
+        "owners.email",
+        "owners.first_name",
+        "owners.last_name",
+        "owners.phone",
+        "owners.ssn_last_4",
+        "owners.verification.document",
+        "representative.address.city",
+        "representative.address.line1",
+        "representative.address.postal_code",
+        "representative.address.state",
+        "representative.dob.day",
+        "representative.dob.month",
+        "representative.dob.year",
+        "representative.email",
+        "representative.first_name",
+        "representative.last_name",
+        "representative.phone",
+        "representative.relationship.executive",
+        "representative.relationship.title",
+        "representative.ssn_last_4",
+        "tos_acceptance.date",
+        "tos_acceptance.ip"
+      ]
+    },
+    "individual": {
+      "additional": [
+        "individual.id_number",
+        "individual.verification.document"
+      ],
+      "minimum": [
+        "business_profile.mcc",
+        "business_profile.url",
+        "business_type",
+        "external_account",
+        "individual.address.city",
+        "individual.address.line1",
+        "individual.address.postal_code",
+        "individual.address.state",
+        "individual.dob.day",
+        "individual.dob.month",
+        "individual.dob.year",
+        "individual.email",
+        "individual.first_name",
+        "individual.last_name",
+        "individual.phone",
+        "individual.ssn_last_4",
+        "tos_acceptance.date",
+        "tos_acceptance.ip"
+      ]
+    }
+  }
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -2,6 +2,14 @@ require 'sinatra/base'
 
 module FakeStripe
   class StubApp < Sinatra::Base
+    # Country Specs
+    get '/v1/country_specs' do
+      json_response 201, fixture('list_country_specs')
+    end
+    get '/v1/country_specs/:id' do
+      json_response 201, fixture('retrieve_country_spec')
+    end
+
     # Terminal
 
     # Connection tokens

--- a/spec/fake_stripe/requests/stub_app_spec.rb
+++ b/spec/fake_stripe/requests/stub_app_spec.rb
@@ -4,6 +4,10 @@ describe 'Stub app' do
   include Rack::Test::Methods
 
   TESTS = {
+    # Country Specs
+    'GET /country_specs' => { route: '/v1/country_specs', method: :get},
+    'GET /country_specs/:id' => { route: '/v1/country_specs/:id', method: :get},
+
     # Charges
     'POST charges' => { route: '/v1/charges', method: :post },
     'GET charges/:charge_id' => { route: '/v1/charges/1', method: :get },

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -1,6 +1,23 @@
 require 'spec_helper'
 
 describe FakeStripe::StubApp do
+  # Country Specs
+  describe "GET /v1/country_specs" do
+    it "returns a list of country specs" do
+      result = Stripe::CountrySpec.list({limit: 100})
+
+      expect(result.data.first.object).to eq("country_spec")
+    end
+  end
+  describe "GET /v1/country_specs/:id" do
+    it "returns a list of country specs" do
+      result = Stripe::CountrySpec.retrieve("US")
+
+      expect(result.object).to eq("country_spec")
+      expect(result.id).to eq("US")
+    end
+  end
+
   # Accounts
   describe "POST /v1/accounts" do
     it "returns an account response" do


### PR DESCRIPTION
This change adds support for the [Stripe Country Specs API](https://stripe.com/docs/api/country_specs), which provides onboarding requirements for the different countries that Stripe supports for [Connect accounts](https://stripe.com/docs/connect/custom-accounts). 

These new endpoints are used in the new [Stripe Connect onboarding](https://stripe.com/docs/connect/connect-onboarding) to allow us to onboard a school that is located in any of the countries that Stripe supports, and surface the currencies you can receive payouts in for selection within the onboarding flow.

![image](https://user-images.githubusercontent.com/1410882/107712882-236b5e80-6c98-11eb-8d07-356be705c2ed.png)


_This will prevent us from having to update onboarding to add support for a school in a new country._

There are two new supported API endpoints added:

- `/v1/country_specs`
- `/v1country_specs/:id`

Which can be used in the [Stripe Ruby API](https://stripe.com/docs/api):

```ruby
# There are currently only 44 country specs returned by the API, so we don't need to worry about pagination...yet.
country_specs = Stripe::CountrySpec.list({ limit: 100 }) 

# OR
country_spec = Stripe::CountrySpec.retrieve("US")
```

Example **`CountrySpec`** object:

```ruby
{
  "id": "US",
  "object": "country_spec",
  "default_currency": "usd",
  "supported_bank_account_currencies": {
    "usd": [
      "US"
    ]
  },
  "supported_payment_currencies": [
    "usd",
    "aed",
    "afn",
    "..."
  ],
  "supported_payment_methods": [
    "ach",
    "card",
    "stripe"
  ],
  "supported_transfer_countries": [
    "US",
    "AT",
    "AU",
    "BE",
    "BG",
    "CA",
    "CH",
    "CY",
    "CZ",
    "DE",
    "DK",
    "EE",
    "ES",
    "FI",
    "FR",
    "GB",
    "GR",
    "HK",
    "IE",
    "IT",
    "LT",
    "LU",
    "LV",
    "MT",
    "NL",
    "NO",
    "NZ",
    "PL",
    "PT",
    "RO",
    "SE",
    "SG",
    "SI",
    "SK"
  ],
  "verification_fields": {
    "company": {
      "additional": [
        "representative.verification.document"
      ],
      "minimum": [
        "business_profile.mcc",
        "business_profile.url",
        "business_type",
        "company.address.city",
        "company.address.line1",
        "company.address.postal_code",
        "company.address.state",
        "company.name",
        "company.owners_provided",
        "company.phone",
        "company.tax_id",
        "external_account",
        "owners.address.city",
        "owners.address.line1",
        "owners.address.postal_code",
        "owners.address.state",
        "owners.dob.day",
        "owners.dob.month",
        "owners.dob.year",
        "owners.email",
        "owners.first_name",
        "owners.last_name",
        "owners.phone",
        "owners.ssn_last_4",
        "owners.verification.document",
        "representative.address.city",
        "representative.address.line1",
        "representative.address.postal_code",
        "representative.address.state",
        "representative.dob.day",
        "representative.dob.month",
        "representative.dob.year",
        "representative.email",
        "representative.first_name",
        "representative.last_name",
        "representative.phone",
        "representative.relationship.executive",
        "representative.relationship.title",
        "representative.ssn_last_4",
        "tos_acceptance.date",
        "tos_acceptance.ip"
      ]
    },
    "individual": {
      "additional": [
        "individual.id_number",
        "individual.verification.document"
      ],
      "minimum": [
        "business_profile.mcc",
        "business_profile.url",
        "business_type",
        "external_account",
        "individual.address.city",
        "individual.address.line1",
        "individual.address.postal_code",
        "individual.address.state",
        "individual.dob.day",
        "individual.dob.month",
        "individual.dob.year",
        "individual.email",
        "individual.first_name",
        "individual.last_name",
        "individual.phone",
        "individual.ssn_last_4",
        "tos_acceptance.date",
        "tos_acceptance.ip"
      ]
    }
  }
}

```