### PR TITLE
Add saved payment method to customer fixture

### DIFF
--- a/lib/fake_stripe/fixtures/create_customer.json
+++ b/lib/fake_stripe/fixtures/create_customer.json
@@ -13,7 +13,7 @@
   "invoice_prefix": "BC6A818",
   "invoice_settings": {
     "custom_fields": null,
-    "default_payment_method": null,
+    "default_payment_method": "pm_1FzVb62eZvKYlo2CKPwNF9Bz",
     "footer": null
   },
   "livemode": false,

--- a/spec/fake_stripe/stub_app_spec.rb
+++ b/spec/fake_stripe/stub_app_spec.rb
@@ -299,6 +299,13 @@ describe FakeStripe::StubApp do
 
   # Customers
   describe "POST /v1/customers" do
+    it "returns a customer with a default payment method" do
+      customer = Stripe::Customer.create
+      payment_method = Stripe::PaymentMethod.create
+
+      expect(customer.invoice_settings.default_payment_method).to eq(payment_method.id)
+      expect(customer.id).to eq(payment_method.customer)
+    end
     it "increments the customer counter" do
       expect do
         Stripe::Customer.create


### PR DESCRIPTION
This change adds the default payment method to the `Stripe::Customer` fixture so that returning `customer.invoice_settings.default_payment_method` will return the same `PaymentMethod.id` used throughout the library.