### PR TITLE
add sources to charges

### DIFF
--- a/lib/fake_stripe/fixtures/capture_payment_intent.json
+++ b/lib/fake_stripe/fixtures/capture_payment_intent.json
@@ -93,6 +93,7 @@
         },
         "review": null,
         "shipping": null,
+        "source": null,
         "source_transfer": null,
         "statement_descriptor": null,
         "statement_descriptor_suffix": null,

--- a/lib/fake_stripe/fixtures/confirm_payment_intent.json
+++ b/lib/fake_stripe/fixtures/confirm_payment_intent.json
@@ -93,6 +93,7 @@
         },
         "review": null,
         "shipping": null,
+        "source": null,
         "source_transfer": null,
         "statement_descriptor": null,
         "statement_descriptor_suffix": null,


### PR DESCRIPTION
Missing "sources" method is raising an error while testing recurring set-up