### PR TITLE
Update fixtures for Stripe API Upgrade

### DIFF
--- a/lib/fake_stripe/fixtures/list_refunds.json
+++ b/lib/fake_stripe/fixtures/list_refunds.json
@@ -13,7 +13,7 @@
       "currency": "usd",
       "metadata": {},
       "payment_intent": null,
-      "reason": null,
+      "reason": "Some Reason",
       "receipt_number": null,
       "source_transfer_reversal": null,
       "status": "succeeded",

--- a/lib/fake_stripe/fixtures/retrieve_payment_intent.json
+++ b/lib/fake_stripe/fixtures/retrieve_payment_intent.json
@@ -57,6 +57,7 @@
     },
     "type": "invalid_request_error"
   },
+  "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
   "charges": {
     "object": "list",
     "data": [


### PR DESCRIPTION
- Adds new `latest_charge` attribute to the `payment_intent` fixture
- Updates the refund reason to `Some Reason` on the refund fixture