### PR TITLE
Update fixtures to support latest_charge

### DIFF
--- a/lib/fake_stripe/fixtures/capture_payment_intent.json
+++ b/lib/fake_stripe/fixtures/capture_payment_intent.json
@@ -112,6 +112,7 @@
   "customer": null,
   "description": "One blue fish",
   "invoice": null,
+  "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
   "last_payment_error": null,
   "livemode": false,
   "metadata": {},

--- a/lib/fake_stripe/fixtures/confirm_payment_intent.json
+++ b/lib/fake_stripe/fixtures/confirm_payment_intent.json
@@ -113,6 +113,7 @@
   "description": "One blue fish",
   "invoice": null,
   "last_payment_error": null,
+  "latest_charge": "ch_1Gkt7f2eZvKYlo2CVzqe4sgl",
   "livemode": false,
   "metadata": {},
   "next_action": null,

--- a/lib/fake_stripe/fixtures/create_payment_intent.json
+++ b/lib/fake_stripe/fixtures/create_payment_intent.json
@@ -23,6 +23,7 @@
   "description": null,
   "invoice": null,
   "last_payment_error": null,
+  "latest_charge": "ch_1Gkt7f2eZvKYlo2CVzqe4sgl",
   "livemode": false,
   "metadata": {},
   "next_action": null,

--- a/lib/fake_stripe/fixtures/list_payment_intents.json
+++ b/lib/fake_stripe/fixtures/list_payment_intents.json
@@ -28,6 +28,7 @@
       "description": null,
       "invoice": null,
       "last_payment_error": null,
+      "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
       "livemode": false,
       "metadata": {
         "order_id": "6789"

--- a/lib/fake_stripe/fixtures/retrieve_payment_intent.json
+++ b/lib/fake_stripe/fixtures/retrieve_payment_intent.json
@@ -57,7 +57,6 @@
     },
     "type": "invalid_request_error"
   },
-  "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
   "charges": {
     "object": "list",
     "data": [
@@ -170,6 +169,7 @@
   "customer": null,
   "description": null,
   "invoice": null,
+  "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
   "livemode": false,
   "metadata": {},
   "next_action": null,

--- a/lib/fake_stripe/fixtures/update_payment_intent.json
+++ b/lib/fake_stripe/fixtures/update_payment_intent.json
@@ -22,6 +22,7 @@
   "customer": "cus_HJYfEnsfVLxB3C",
   "description": null,
   "invoice": null,
+  "latest_charge": "ch_18uPw8L91mzKIzpGAYTRv8jQ",
   "last_payment_error": null,
   "livemode": false,
   "metadata": {


### PR DESCRIPTION
Add support for `latest_charge` for payment_intent fixtures.