### PR TITLE
Support us_bank_account PaymentMethods (OG-2313)

### DIFF
--- a/lib/fake_stripe/fixtures/attach_us_bank_account_payment_method_to_customer.json
+++ b/lib/fake_stripe/fixtures/attach_us_bank_account_payment_method_to_customer.json
@@ -1,0 +1,38 @@
+{
+  "id": "pm_usba_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "US",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "John Doe",
+    "phone": null
+  },
+  "created": 1589985641,
+  "customer": "cus_HJYfEnsfVLxB3C",
+  "livemode": false,
+  "metadata": {},
+  "type": "us_bank_account",
+  "us_bank_account": {
+    "account_holder_type": "individual",
+    "account_type": "checking",
+    "bank_name": "STRIPE TEST BANK",
+    "financial_connections_account": null,
+    "fingerprint": "LstWJFsCK7P349Bg",
+    "last4": "6789",
+    "networks": {
+      "preferred": "ach",
+      "supported": [
+        "ach"
+      ]
+    },
+    "routing_number": "110000000",
+    "status_details": {}
+  }
+}

--- a/lib/fake_stripe/fixtures/create_us_bank_account_payment_method.json
+++ b/lib/fake_stripe/fixtures/create_us_bank_account_payment_method.json
@@ -1,0 +1,38 @@
+{
+  "id": "pm_usba_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "US",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "John Doe",
+    "phone": null
+  },
+  "created": 1578693892,
+  "customer": null,
+  "livemode": false,
+  "metadata": {},
+  "type": "us_bank_account",
+  "us_bank_account": {
+    "account_holder_type": "individual",
+    "account_type": "checking",
+    "bank_name": "STRIPE TEST BANK",
+    "financial_connections_account": null,
+    "fingerprint": "LstWJFsCK7P349Bg",
+    "last4": "6789",
+    "networks": {
+      "preferred": "ach",
+      "supported": [
+        "ach"
+      ]
+    },
+    "routing_number": "110000000",
+    "status_details": {}
+  }
+}

--- a/lib/fake_stripe/fixtures/detach_us_bank_account_payment_method_from_customer.json
+++ b/lib/fake_stripe/fixtures/detach_us_bank_account_payment_method_from_customer.json
@@ -1,0 +1,38 @@
+{
+  "id": "pm_usba_1GkvYE2eZvKYlo2CTnuIhVrz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "US",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "John Doe",
+    "phone": null
+  },
+  "created": 1589995074,
+  "customer": null,
+  "livemode": false,
+  "metadata": {},
+  "type": "us_bank_account",
+  "us_bank_account": {
+    "account_holder_type": "individual",
+    "account_type": "checking",
+    "bank_name": "STRIPE TEST BANK",
+    "financial_connections_account": null,
+    "fingerprint": "LstWJFsCK7P349Bg",
+    "last4": "6789",
+    "networks": {
+      "preferred": "ach",
+      "supported": [
+        "ach"
+      ]
+    },
+    "routing_number": "110000000",
+    "status_details": {}
+  }
+}

--- a/lib/fake_stripe/fixtures/list_us_bank_account_payment_methods.json
+++ b/lib/fake_stripe/fixtures/list_us_bank_account_payment_methods.json
@@ -1,0 +1,45 @@
+{
+  "object": "list",
+  "url": "/v1/payment_methods",
+  "has_more": false,
+  "data": [
+    {
+      "id": "pm_usba_1FzVb62eZvKYlo2CKPwNF9Bz",
+      "object": "payment_method",
+      "billing_details": {
+        "address": {
+          "city": null,
+          "country": "US",
+          "line1": null,
+          "line2": null,
+          "postal_code": null,
+          "state": null
+        },
+        "email": null,
+        "name": "John Doe",
+        "phone": null
+      },
+      "created": 1595870253,
+      "customer": "cus_HJYfEnsfVLxB3C",
+      "livemode": false,
+      "metadata": {},
+      "type": "us_bank_account",
+      "us_bank_account": {
+        "account_holder_type": "individual",
+        "account_type": "checking",
+        "bank_name": "STRIPE TEST BANK",
+        "financial_connections_account": null,
+        "fingerprint": "LstWJFsCK7P349Bg",
+        "last4": "6789",
+        "networks": {
+          "preferred": "ach",
+          "supported": [
+            "ach"
+          ]
+        },
+        "routing_number": "110000000",
+        "status_details": {}
+      }
+    }
+  ]
+}

--- a/lib/fake_stripe/fixtures/retrieve_us_bank_account_payment_method.json
+++ b/lib/fake_stripe/fixtures/retrieve_us_bank_account_payment_method.json
@@ -1,0 +1,38 @@
+{
+  "id": "pm_usba_1FzVb62eZvKYlo2CKPwNF9Bz",
+  "object": "payment_method",
+  "billing_details": {
+    "address": {
+      "city": null,
+      "country": "US",
+      "line1": null,
+      "line2": null,
+      "postal_code": null,
+      "state": null
+    },
+    "email": null,
+    "name": "John Doe",
+    "phone": null
+  },
+  "created": 1578693892,
+  "customer": "cus_HJYfEnsfVLxB3C",
+  "livemode": false,
+  "metadata": {},
+  "type": "us_bank_account",
+  "us_bank_account": {
+    "account_holder_type": "individual",
+    "account_type": "checking",
+    "bank_name": "STRIPE TEST BANK",
+    "financial_connections_account": null,
+    "fingerprint": "LstWJFsCK7P349Bg",
+    "last4": "6789",
+    "networks": {
+      "preferred": "ach",
+      "supported": [
+        "ach"
+      ]
+    },
+    "routing_number": "110000000",
+    "status_details": {}
+  }
+}

--- a/lib/fake_stripe/stub_app.rb
+++ b/lib/fake_stripe/stub_app.rb
@@ -241,11 +241,15 @@ module FakeStripe
     # Pyment Methods
     post '/v1/payment_methods' do
       FakeStripe.payment_method_count += 1
-      json_response 201, fixture('create_payment_method')
+      if params[:type].to_s == "us_bank_account"
+        json_response 201, fixture('create_us_bank_account_payment_method')
+      else
+        json_response 201, fixture('create_payment_method')
+      end
     end
 
     get '/v1/payment_methods/:payment_method_id' do
-      json_response 200, fixture('retrieve_payment_method')
+      json_response 200, fixture(payment_method_fixture_for(params[:payment_method_id], 'retrieve_payment_method'))
     end
 
     post '/v1/payment_methods/:payment_method_id' do
@@ -253,15 +257,19 @@ module FakeStripe
     end
 
     get '/v1/payment_methods' do
-      json_response 200, fixture('list_payment_methods')
+      if params[:type].to_s == "us_bank_account"
+        json_response 200, fixture('list_us_bank_account_payment_methods')
+      else
+        json_response 200, fixture('list_payment_methods')
+      end
     end
 
     post '/v1/payment_methods/:payment_method_id/attach' do
-      json_response 200, fixture('attach_payment_method_to_customer')
+      json_response 200, fixture(payment_method_fixture_for(params[:payment_method_id], 'attach_payment_method_to_customer'))
     end
 
     post '/v1/payment_methods/:payment_method_id/detach' do
-      json_response 200, fixture('detach_payment_method_from_customer')
+      json_response 200, fixture(payment_method_fixture_for(params[:payment_method_id], 'detach_payment_method_from_customer'))
     end
 
     # Bank Account (payment methods)
@@ -986,6 +994,20 @@ module FakeStripe
         "create_bank_account_token"
       else
         "create_card_token"
+      end
+    end
+
+    # Sentinel-id routing for PaymentMethod retrieve/attach/detach. Ids
+    # prefixed with pm_usba_ return the us_bank_account variant of the given
+    # default fixture (e.g. retrieve_payment_method ->
+    # retrieve_us_bank_account_payment_method), so tests can exercise the ACH
+    # bank-account PaymentMethods flow. Any other id falls back to the default
+    # (card) fixture.
+    def payment_method_fixture_for(id, default)
+      if id.to_s.start_with?('pm_usba_')
+        default.sub('payment_method', 'us_bank_account_payment_method')
+      else
+        default
       end
     end
 

--- a/spec/fake_stripe/requests/payment_method_us_bank_account_spec.rb
+++ b/spec/fake_stripe/requests/payment_method_us_bank_account_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe 'Stub app PaymentMethod us_bank_account branching' do
+  describe 'POST /v1/payment_methods' do
+    it 'returns a us_bank_account payment method when type is us_bank_account' do
+      payment_method = Stripe::PaymentMethod.create({
+        type: 'us_bank_account',
+        us_bank_account: {
+          account_holder_type: 'individual',
+          account_number: '000123456789',
+          routing_number: '110000000',
+        },
+      })
+
+      expect(payment_method.type).to eq('us_bank_account')
+      expect(payment_method.us_bank_account.bank_name).to eq('STRIPE TEST BANK')
+      expect(payment_method.us_bank_account.last4).to eq('6789')
+      expect(payment_method.us_bank_account.routing_number).to eq('110000000')
+    end
+
+    it 'still returns a card payment method by default' do
+      payment_method = Stripe::PaymentMethod.create
+
+      expect(payment_method.type).to eq('card')
+    end
+  end
+
+  describe 'GET /v1/payment_methods' do
+    it 'returns us_bank_account payment methods when type is us_bank_account' do
+      result = Stripe::PaymentMethod.list({
+        customer: 'cus_HJYfEnsfVLxB3C',
+        type: 'us_bank_account',
+      })
+
+      expect(result.count).to eq(1)
+      expect(result.data.first.type).to eq('us_bank_account')
+      expect(result.data.first.us_bank_account.bank_name).to eq('STRIPE TEST BANK')
+      expect(result.data.first.us_bank_account.last4).to eq('6789')
+    end
+
+    it 'still returns card payment methods for type card' do
+      result = Stripe::PaymentMethod.list({
+        customer: 'cus_HJYfEnsfVLxB3C',
+        type: 'card',
+      })
+
+      expect(result.data.first.type).to eq('card')
+    end
+  end
+
+  describe 'GET /v1/payment_methods/:id' do
+    it 'returns a us_bank_account payment method for ids prefixed with pm_usba_' do
+      payment_method = Stripe::PaymentMethod.retrieve('pm_usba_test123')
+
+      expect(payment_method.type).to eq('us_bank_account')
+      expect(payment_method.us_bank_account.bank_name).to eq('STRIPE TEST BANK')
+      expect(payment_method.us_bank_account.account_type).to eq('checking')
+    end
+
+    it 'returns a card payment method for any other id' do
+      payment_method = Stripe::PaymentMethod.retrieve('pm_1FzVb62eZvKYlo2CKPwNF9Bz')
+
+      expect(payment_method.type).to eq('card')
+    end
+  end
+
+  describe 'POST /v1/payment_methods/:id/attach' do
+    it 'returns a us_bank_account payment method for ids prefixed with pm_usba_' do
+      result = Stripe::PaymentMethod.attach('pm_usba_test123', {customer: 'cus_HJYfEnsfVLxB3C'})
+
+      expect(result.type).to eq('us_bank_account')
+      expect(result.customer).to eq('cus_HJYfEnsfVLxB3C')
+    end
+  end
+
+  describe 'POST /v1/payment_methods/:id/detach' do
+    it 'returns a us_bank_account payment method for ids prefixed with pm_usba_' do
+      result = Stripe::PaymentMethod.detach('pm_usba_test123')
+
+      expect(result.type).to eq('us_bank_account')
+      expect(result.customer).to be_nil
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The PaymentMethods endpoints in the stub always returned a card-shaped fixture, regardless of the requested `type`. With the GiveCampus app's ACH migration (legacy Sources API → PaymentMethods API for US bank accounts, see OG-2285), code paths that list/retrieve a saved bank account now hit `PaymentMethod.list(type: "us_bank_account")` and read the `us_bank_account` hash — which the stub never returned, so the real Stripe gem raised `NoMethodError` on the missing attribute.

This PR adds `us_bank_account` fidelity across the full PaymentMethod lifecycle, following the fork's existing conventions (type-aware fixtures + id sentinels):

- **create** (`POST /v1/payment_methods`) and **list** (`GET /v1/payment_methods`) branch on the request `type` param → return the `us_bank_account` fixture when `type=us_bank_account`, otherwise the existing card fixture.
- **retrieve / attach / detach** branch on a `pm_usba_` id sentinel → return the `us_bank_account` variant of the relevant fixture, otherwise the card fixture.

## Changes

- Five new fixtures: `create`, `retrieve`, `list`, `attach`, `detach` us_bank_account PaymentMethod variants (modeled on the real Stripe `us_bank_account` object — account_holder_type, account_type, bank_name, fingerprint, last4, routing_number, networks).
- `payment_method_fixture_for(id, default)` helper that maps a default (card) fixture name to its us_bank_account variant for `pm_usba_`-prefixed ids.
- New spec `spec/fake_stripe/requests/payment_method_us_bank_account_spec.rb` covering all five operations (8 examples).

## Testing

- New spec: 8 examples, 0 failures.
- Full suite: the only 3 failures are pre-existing on `main` (Stripe gem version drift — `Stripe::Recipient` removed, etc.), unrelated to this change.

## Follow-up

Once merged, bump the `fake_stripe` revision in `givecampus/givecampus`'s `Gemfile.lock` (OG-2313 AC).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
